### PR TITLE
auth の状態をチェックしてから client.start() するよう修正

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -1,4 +1,7 @@
 import client from '.spat/modules/client';
 
 client.showSSR();
-client.start();
+
+firebase.auth().checkAuth().then((user) => {
+  client.start();
+});

--- a/app/plugins/firebase.js
+++ b/app/plugins/firebase.js
@@ -1,8 +1,37 @@
 import firebase from 'firebase/app';
+import 'firebase/auth';
 import 'firebase/firestore';
 
 firebase.initializeApp(spat.config.firebase);
 
+// setup auth
+var auth = firebase.auth();
+// auth チェック用 promise
+auth.authPromise = new Promise((resolve) => {
+  var completed = auth.onIdTokenChanged(async (user) => {
+    // 監視を停止
+    completed();
+
+    if (user) {
+      resolve(user);
+    }
+    else {
+      resolve(null);
+    }
+  });
+});
+
+// auth の状態をする関数
+auth.checkAuth = () => {
+  if (auth.currentUser) {
+    return Promise.resolve(auth.currentUser);
+  }
+  else {
+    return auth.authPromise;
+  }
+};
+
+// setup db
 var db = firebase.firestore();
 
 if (spat.isBrowser) {


### PR DESCRIPTION
firebase.auth() の currentUser はページ読み込み時は null  なので単純に存在チェックでログインしているかどうかをチェックすることはできません.

token が変わるイベント時に初期化されて, ログインしている場合そのとき始めて currentUser に値が代入されるので, そのチェックを待ってから client.start() するようにしてます.

よかったら参考にしてください.